### PR TITLE
Jm/odometry path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ find_package(tf2_ros REQUIRED)
 
 set(rviz_dynamic_slam_plugins_headers_to_moc
   include/rviz_dynamic_slam_plugins/object_odometry_display.hpp
+  include/rviz_dynamic_slam_plugins/object_odometry_path_display.hpp
 )
 
 foreach(header "${rviz_dynamic_slam_plugins_headers_to_moc}")
@@ -84,6 +85,7 @@ endforeach()
 
 set(rviz_dynamic_slam_plugins_source_files
   src/object_odometry_display.cc
+  src/object_odometry_path_display.cc
 )
 
 add_library(rviz_dynamic_slam_plugins SHARED

--- a/include/rviz_dynamic_slam_plugins/object_odometry_path_display.hpp
+++ b/include/rviz_dynamic_slam_plugins/object_odometry_path_display.hpp
@@ -124,58 +124,13 @@ private:
     void allocateAxesVector(std::vector<rviz_rendering::Axes *> & axes_vect, size_t num);
   };
 
-  std::map<int, SingleDisplay> object_data_;
+  SingleDisplay* getSingleDisplay(const ObjectOdometryPath& msg);
 
+  //map of objects id/path segments to displays
+  std::map<std::pair<int, int>, SingleDisplay> object_data_;
 
-//   void destroyObjects();
-//   void allocateArrowVector(std::vector<rviz_rendering::Arrow *> & arrow_vect, size_t num);
-//   void allocateAxesVector(std::vector<rviz_rendering::Axes *> & axes_vect, size_t num);
-//   void destroyPoseAxesChain();
-//   void destroyPoseArrowChain();
-//   void updateManualObject(
-//     Ogre::ManualObject * manual_object, nav_msgs::msg::Path::ConstSharedPtr msg,
-//     const Ogre::Matrix4 & transform);
-//   void updateBillBoardLine(
-//     rviz_rendering::BillboardLine * billboard_line, nav_msgs::msg::Path::ConstSharedPtr msg,
-//     const Ogre::Matrix4 & transform);
-//   void updatePoseMarkers(
-//     size_t buffer_index, nav_msgs::msg::Path::ConstSharedPtr msg, const Ogre::Matrix4 & transform);
-//   void updateAxesMarkers(
-//     std::vector<rviz_rendering::Axes *> & axes_vect, nav_msgs::msg::Path::ConstSharedPtr msg,
-//     const Ogre::Matrix4 & transform);
-//   void updateArrowMarkers(
-//     std::vector<rviz_rendering::Arrow *> & arrow_vect, nav_msgs::msg::Path::ConstSharedPtr msg,
-//     const Ogre::Matrix4 & transform);
-
-//   // std::vector<Ogre::ManualObject *> manual_objects_;
-//   std::vector<rviz_rendering::BillboardLine *> billboard_lines_;
-//   std::vector<std::vector<rviz_rendering::Axes *>> axes_chain_;
-//   std::vector<std::vector<rviz_rendering::Arrow *>> arrow_chain_;
-//   Ogre::MaterialPtr lines_material_;
-
-//   rviz_common::properties::EnumProperty * style_property_;
-//   rviz_common::properties::ColorProperty * color_property_;
-//   rviz_common::properties::FloatProperty * alpha_property_;
-//   rviz_common::properties::FloatProperty * line_width_property_;
   rviz_common::properties::IntProperty * buffer_length_property_;
   PropertyStruct properties;
-//   rviz_common::properties::VectorProperty * offset_property_;
-
-//   enum LineStyle
-//   {
-//     LINES,
-//     BILLBOARDS
-//   };
-
-//   // pose marker property
-//   rviz_common::properties::EnumProperty * pose_style_property_;
-//   rviz_common::properties::FloatProperty * pose_axes_length_property_;
-//   rviz_common::properties::FloatProperty * pose_axes_radius_property_;
-//   rviz_common::properties::ColorProperty * pose_arrow_color_property_;
-//   rviz_common::properties::FloatProperty * pose_arrow_shaft_length_property_;
-//   rviz_common::properties::FloatProperty * pose_arrow_head_length_property_;
-//   rviz_common::properties::FloatProperty * pose_arrow_shaft_diameter_property_;
-//   rviz_common::properties::FloatProperty * pose_arrow_head_diameter_property_;
 
   enum PoseStyle
   {

--- a/include/rviz_dynamic_slam_plugins/object_odometry_path_display.hpp
+++ b/include/rviz_dynamic_slam_plugins/object_odometry_path_display.hpp
@@ -1,0 +1,189 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+
+#ifndef Q_MOC_RUN
+
+// TODO(Martin-Idel-SI): Reenable once available
+// #include <tf/message_filter.h>
+// #include "nav_msgs/msg/odometry.hpp"
+#endif
+
+#include "dynamic_slam_interfaces/msg/multi_object_odometry_path.hpp"
+#include "dynamic_slam_interfaces/msg/object_odometry_path.hpp"
+#include "dynamic_slam_interfaces/message_traits.hpp"
+
+#include "rviz_rendering/objects/covariance_visual.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_rendering/objects/billboard_line.hpp"
+#include "rviz_rendering/objects/movable_text.hpp"
+
+
+namespace rviz_rendering
+{
+class Arrow;
+class Axes;
+}  // namespace rviz_rendering
+
+namespace rviz_common
+{
+namespace properties
+{
+class BoolProperty;
+class ColorProperty;
+class FloatProperty;
+class IntProperty;
+class EnumProperty;
+class CovarianceProperty;
+}  // namespace properties
+}  // namespace rviz_common
+
+namespace rviz_dynamic_slam_plugins
+{
+
+using namespace dynamic_slam_interfaces::msg;
+
+class ObjectOdometryPathDisplay : public
+  rviz_common::MessageFilterDisplay<MultiObjectOdometryPath>
+{
+  Q_OBJECT
+  public:
+  // TODO(Martin-Idel-SI): Constructor for testing, remove once ros_nodes can be mocked and call
+  // initialize() instead
+  explicit ObjectOdometryPathDisplay(rviz_common::DisplayContext * context);
+  ObjectOdometryPathDisplay();
+  ~ObjectOdometryPathDisplay() override;
+
+  /** @brief Overridden from Display. */
+  void reset() override;
+
+  /** @brief Overridden from MessageFilterDisplay. */
+  void processMessage(MultiObjectOdometryPath::ConstSharedPtr msg) override;
+
+protected:
+  /** @brief Overridden from Display. */
+  void onInitialize() override;
+
+private Q_SLOTS:
+  void updateBufferLength();
+  void updateLineWidth();
+  void updatePoseStyle();
+  void updatePoseAxisGeometry();
+  void updatePoseArrowGeometry();
+
+private:
+  void destroyDisplays();
+
+  struct PropertyStruct {
+      // pose marker property
+    rviz_common::properties::EnumProperty * pose_style_property_;
+    rviz_common::properties::FloatProperty * pose_axes_length_property_;
+    rviz_common::properties::FloatProperty * pose_axes_radius_property_;
+    rviz_common::properties::FloatProperty * pose_arrow_shaft_length_property_;
+    rviz_common::properties::FloatProperty * pose_arrow_head_length_property_;
+    rviz_common::properties::FloatProperty * pose_arrow_shaft_diameter_property_;
+    rviz_common::properties::FloatProperty * pose_arrow_head_diameter_property_;
+    rviz_common::properties::FloatProperty * line_width_property_;
+
+  };
+
+
+  struct SingleDisplay : public PropertyStruct  {
+    std::vector<rviz_rendering::BillboardLine *> billboard_lines_;
+    std::vector<std::vector<rviz_rendering::Axes *>> axes_chain_;
+    std::vector<std::vector<rviz_rendering::Arrow *>> arrow_chain_;
+    Ogre::SceneNode* scene_node_;
+    Ogre::SceneManager* scene_manager_;
+
+    void destroyObjects();
+    void destroyPoseAxesChain();
+    void destroyPoseArrowChain();
+
+    void updateBufferLength(size_t buffer_length);
+
+    void updateBillBoardLine(
+      rviz_rendering::BillboardLine * billboard_line, 
+      const ObjectOdometryPath& msg,
+      const Ogre::Matrix4 & transform);
+
+      void updateAxesMarkers(
+        std::vector<rviz_rendering::Axes *> & axes_vect, 
+        const ObjectOdometryPath& msg,
+        const Ogre::Matrix4 & transform);
+      void updateArrowMarkers(
+        std::vector<rviz_rendering::Arrow *> & arrow_vect, 
+        const ObjectOdometryPath& msg,
+        const Ogre::Matrix4 & transform);
+
+    void updatePoseMarkers(size_t buffer_index, 
+      const ObjectOdometryPath& msg,
+      const Ogre::Matrix4 & transform);
+
+    void allocateArrowVector(std::vector<rviz_rendering::Arrow *> & arrow_vect, size_t num);
+    void allocateAxesVector(std::vector<rviz_rendering::Axes *> & axes_vect, size_t num);
+  };
+
+  std::map<int, SingleDisplay> object_data_;
+
+
+//   void destroyObjects();
+//   void allocateArrowVector(std::vector<rviz_rendering::Arrow *> & arrow_vect, size_t num);
+//   void allocateAxesVector(std::vector<rviz_rendering::Axes *> & axes_vect, size_t num);
+//   void destroyPoseAxesChain();
+//   void destroyPoseArrowChain();
+//   void updateManualObject(
+//     Ogre::ManualObject * manual_object, nav_msgs::msg::Path::ConstSharedPtr msg,
+//     const Ogre::Matrix4 & transform);
+//   void updateBillBoardLine(
+//     rviz_rendering::BillboardLine * billboard_line, nav_msgs::msg::Path::ConstSharedPtr msg,
+//     const Ogre::Matrix4 & transform);
+//   void updatePoseMarkers(
+//     size_t buffer_index, nav_msgs::msg::Path::ConstSharedPtr msg, const Ogre::Matrix4 & transform);
+//   void updateAxesMarkers(
+//     std::vector<rviz_rendering::Axes *> & axes_vect, nav_msgs::msg::Path::ConstSharedPtr msg,
+//     const Ogre::Matrix4 & transform);
+//   void updateArrowMarkers(
+//     std::vector<rviz_rendering::Arrow *> & arrow_vect, nav_msgs::msg::Path::ConstSharedPtr msg,
+//     const Ogre::Matrix4 & transform);
+
+//   // std::vector<Ogre::ManualObject *> manual_objects_;
+//   std::vector<rviz_rendering::BillboardLine *> billboard_lines_;
+//   std::vector<std::vector<rviz_rendering::Axes *>> axes_chain_;
+//   std::vector<std::vector<rviz_rendering::Arrow *>> arrow_chain_;
+//   Ogre::MaterialPtr lines_material_;
+
+//   rviz_common::properties::EnumProperty * style_property_;
+//   rviz_common::properties::ColorProperty * color_property_;
+//   rviz_common::properties::FloatProperty * alpha_property_;
+//   rviz_common::properties::FloatProperty * line_width_property_;
+  rviz_common::properties::IntProperty * buffer_length_property_;
+  PropertyStruct properties;
+//   rviz_common::properties::VectorProperty * offset_property_;
+
+//   enum LineStyle
+//   {
+//     LINES,
+//     BILLBOARDS
+//   };
+
+//   // pose marker property
+//   rviz_common::properties::EnumProperty * pose_style_property_;
+//   rviz_common::properties::FloatProperty * pose_axes_length_property_;
+//   rviz_common::properties::FloatProperty * pose_axes_radius_property_;
+//   rviz_common::properties::ColorProperty * pose_arrow_color_property_;
+//   rviz_common::properties::FloatProperty * pose_arrow_shaft_length_property_;
+//   rviz_common::properties::FloatProperty * pose_arrow_head_length_property_;
+//   rviz_common::properties::FloatProperty * pose_arrow_shaft_diameter_property_;
+//   rviz_common::properties::FloatProperty * pose_arrow_head_diameter_property_;
+
+  enum PoseStyle
+  {
+    NONE,
+    AXES,
+    ARROWS,
+  };
+};
+
+}  // namespace rviz_dynamic_slam_plugins
+

--- a/plugins_description.xml
+++ b/plugins_description.xml
@@ -9,4 +9,15 @@
     </description>
     <message_type>dynamic_slam_interfaces/msg/ObjectOdometry</message_type>
   </class>
+
+  <class
+    name="rviz_dynamic_slam_plugins/ObjectOdometryPath"
+    type="rviz_dynamic_slam_plugins::ObjectOdometryPathDisplay"
+    base_class_type="rviz_common::Display"
+  >
+  <description>
+      Displays from dynamic_slam_interfaces/MultiObjectOdometryPath message
+    </description>
+    <message_type>dynamic_slam_interfaces/msg/MultiObjectOdometryPath</message_type>
+  </class>
 </library>

--- a/src/object_odometry_display.cc
+++ b/src/object_odometry_display.cc
@@ -23,90 +23,54 @@ namespace rviz_dynamic_slam_plugins
 
 ObjectOdometryDisplay::ObjectOdometryDisplay(
   rviz_common::DisplayContext * display_context, Ogre::SceneNode * scene_node)
+: ObjectOdometryDisplay() 
 {
-  setupProperties();
   context_ = display_context;
   scene_node_ = scene_node;
   scene_manager_ = context_->getSceneManager();
-  updateTrajectoryBufferLength();
 }
 
 ObjectOdometryDisplay::ObjectOdometryDisplay()
 {
-  setupProperties();
-}
-
-ObjectOdometryDisplay::~ObjectOdometryDisplay() {
-  reset();
-  // destroyTrajectoryObjects();
-}
-
-void ObjectOdometryDisplay::setupProperties() {
-  show_trajectory_property_ = new rviz_common::properties::BoolProperty(
-    "Trajectory", true,
-    "Whether or not to show the trajectory of all objects.",
-    this, SLOT(updateShowTrajectory()), this);
-
   show_covariance_property_ = new rviz_common::properties::CovarianceProperty(
     "Covariance", true,
     "Whether or not the covariances of the messages should be shown.",
     this, SLOT(updateCovariances()));
 
   show_velocity_property_ = new rviz_common::properties::BoolProperty(
-    "Show Velocity", true,
+    "Velocity", true,
     "Whether or not to show the current velocity of all objects.",
     this, SLOT(updateShowVelocity()), this);
 
-  show_only_last_pose_property_ = new rviz_common::properties::BoolProperty(
-    "Show Only Final Pose", true,
-    "Whether or not to only the final pose of each object. Indepenant of showing the trajectory.",
-    this, SLOT(updateShowPoses()), this);
-
-  style_property_ = new rviz_common::properties::EnumProperty(
-    "Line Style", "Billboards",
-    "The rendering operation to use to draw the grid lines.",
-    show_trajectory_property_, SLOT(updateTrajectoryStyle()), this);
-  style_property_->addOption("Lines", LINES);
-  style_property_->addOption("Billboards", BILLBOARDS);
-
-  buffer_length_property_ = new rviz_common::properties::IntProperty(
-    "Buffer Length", 1,
-    "Number of paths to display.",
-    show_trajectory_property_, SLOT(updateTrajectoryBufferLength()), this);
-  buffer_length_property_->setMin(1);
-
-
   show_object_label_property_ = new rviz_common::properties::BoolProperty(
-    "Show Object Label", true,
+    "Object Label", true,
     "Whether or not to show the object label of all objects.",
     this, SLOT(updateShowObjectLabel()), this);
-
-  keep_property_ = new rviz_common::properties::IntProperty(
-    "Keep", 100,
-    "Number of arrows to keep before removing the oldest.  0 means keep all of them.",
-    this);
-  keep_property_->setMin(0);
-
-  path_diameter_property_ = new rviz_common::properties::FloatProperty(
-    "Diameter", 0.2, "Diamter (m) of the object paths.",
-    show_trajectory_property_, SLOT(updatePathDiameter()), this);
-  path_diameter_property_->setMin(0.001f);
-  // path_diameter_property_->hide();
-
-
+  
   axes_length_property_ = new rviz_common::properties::FloatProperty(
-    "Axes Length", 1, "Length of each axis, in meters.",
+    "Axes Length", 0.5, "Length of each axis, in meters.",
     this, SLOT(updateAxisGeometry()), this);
 
   axes_radius_property_ = new rviz_common::properties::FloatProperty(
-    "Axes Radius", 0.1f, "Radius of each axis, in meters.",
+    "Axes Radius", 0.03f, "Radius of each axis, in meters.",
     this, SLOT(updateAxisGeometry()), this);
+
+  keep_property_ = new rviz_common::properties::IntProperty(
+    "Keep", 1,
+    "Number of arrows to keep before removing the oldest.  0 means keep all of them.",
+    this);
+  keep_property_->setMin(0);
+}
+
+ObjectOdometryDisplay::~ObjectOdometryDisplay() {
+  // reset();
+  // destroyTrajectoryObjects();
 }
 
 
 void ObjectOdometryDisplay::onInitialize() {
   MFDClass::onInitialize();
-  updateTrajectoryBufferLength();
+  // updateTrajectoryBufferLength();
   // updateShapeChoice();
 }
 
@@ -114,8 +78,13 @@ void ObjectOdometryDisplay::onInitialize() {
 void ObjectOdometryDisplay::reset() {
   MFDClass::reset();
   clear();
-  // updateTrajectoryBufferLength();
 }
+
+void ObjectOdometryDisplay::onEnable() {
+  MFDClass::onEnable();
+  // updateShapeVisibility();
+}
+
 
 void ObjectOdometryDisplay::update(float wall_dt, float ros_dt) {
   (void) wall_dt;
@@ -124,16 +93,16 @@ void ObjectOdometryDisplay::update(float wall_dt, float ros_dt) {
   size_t keep = keep_property_->getInt();
 
 
-  auto keep_per_object = [keep](ObjectMetaData& object_meta_data) -> void {
+  auto keep_per_object = [keep](SingleDisplay& disp) -> void {
     if (keep > 0) {
-      while (object_meta_data.axes_.size() > keep) {
-        object_meta_data.axes_.pop_front();
-        object_meta_data.covariances_.pop_front();
+      while (disp.axes_.size() > keep) {
+        disp.axes_.pop_front();
+        disp.covariances_.pop_front();
       }
     }
   };
 
-  for(auto&[object_label, meta_data] : object_data_) {
+  for(auto&[_, meta_data] : object_data_) {
      keep_per_object(meta_data);
   }
 
@@ -143,310 +112,117 @@ void ObjectOdometryDisplay::processMessage(dynamic_slam_interfaces::msg::ObjectO
   // if (!messageIsValid(msg) || messageIsSimilarToPrevious(msg)) {
   //   return;
   // }
-  // std::cout << "Here " <<std::endl;
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->transform(msg->odom.header, msg->odom.pose.pose, position, orientation)) {
     setMissingTransformToFixedFrame(msg->odom.header.frame_id);
     return;
   }
-
-  // std::cout << "Made it " <<std::endl;
   setTransformOk();
-  addObjectData(position, orientation, msg);
+  SingleDisplay* display = getSingleDisplay(msg);
+
+  display->createAndAddAxes(position, orientation, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
+  display->createAndAddCovarianceVisual(position, orientation, msg);
+  display->object_label_scene_node_->setPosition(position);
+
+
   queueRender();
-
-
-}
-
-void ObjectOdometryDisplay::onEnable() {
-  MFDClass::onEnable();
-  updateShapeVisibility();
 }
 
 
-void ObjectOdometryDisplay::clear() {
-  destroyTrajectoryObjects();
-  object_data_.clear();
 
+ObjectOdometryDisplay::SingleDisplay* ObjectOdometryDisplay::getSingleDisplay(ObjectOdometry::ConstSharedPtr msg) {
+  int object_label = msg->object_id;
+
+  SingleDisplay* display = nullptr;
+
+  if (object_data_.find(object_label) == object_data_.end()) {
+    SingleDisplay object_display;
+    object_display.scene_node_ = scene_node_->createChildSceneNode();
+    object_display.object_label_scene_node_ = scene_node_->createChildSceneNode();
+    object_display.scene_manager_ = scene_manager_;
+    object_display.show_covariance_property_ = show_covariance_property_;
+
+    const std::string label = "object " + std::to_string(msg->object_id);
+    object_display.object_label_ = new rviz_rendering::MovableText(label, "Liberation Sans", 0.1f);
+
+    //attach object to object scene scene node
+    object_display.object_label_scene_node_->attachObject(object_display.object_label_);
+    object_display.object_label_->setTextAlignment(
+      rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_CENTER);
+
+    Ogre::ColourValue colour(0.23,0.159,0, 1);
+    object_display.object_label_->setColor(colour);
+    object_data_.emplace(object_label, std::move(object_display));
+  }
+
+  display = &object_data_.at(object_label);
+  assert (display != nullptr);
+  return display;
 }
+
 
 void ObjectOdometryDisplay::updateCovariances() {
-  auto update_per_object = [&](ObjectMetaData& object_meta_data) {
-    for (const auto & covariance : object_meta_data.covariances_) {
+  auto update_per_object = [&](SingleDisplay& disp) {
+    for (const auto & covariance : disp.covariances_) {
       covariance->updateUserData(show_covariance_property_->getUserData());
     }
   };
-  for(auto&[_, object_meta_data] : object_data_) { update_per_object(object_meta_data); }
+  for(auto&[_, disp] : object_data_) { update_per_object(disp); }
 
   context_->queueRender();
 
-}
-
-void ObjectOdometryDisplay::updateShowTrajectory() {
-  bool show_traj = show_trajectory_property_->getBool();
-  auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-
-  auto update_per_object = [&, show_traj, style](ObjectMetaData& object_meta_data) {
-    switch (style) {
-      case LINES:
-        // for(auto manual_object : object_meta_data.manual_objects_) {
-        //   if(manual_object) manual_object->
-        // }
-        // break;
-        std::cout << "LINES not implemented" <<std::endl;
-        break;
-
-      case BILLBOARDS:  // billboards with configurable width
-         for(auto billboard : object_meta_data.billboard_lines_) {
-          if(billboard) billboard->getSceneNode()->setVisible(show_traj);
-        }
-        break;
-    }
-  };
-
-  for(auto&[_, object_meta_data] : object_data_) { update_per_object(object_meta_data); }
 }
 
 void ObjectOdometryDisplay::updateShowVelocity() {
   // bool selectable = show_velocity_property_->getBool();
 }
 
-void ObjectOdometryDisplay::updateShowPoses() {
-  bool show_only_last_pose = show_only_last_pose_property_->getBool();
-  if(show_only_last_pose) {
-    for(auto&[object_label, meta_data] : object_data_) {
-      meta_data.showOnlyFinalPose();
-    }
-  }
-}
-
 void ObjectOdometryDisplay::updateShowObjectLabel() {
   bool show_label = show_object_label_property_->getBool();
-  for(auto&[_, meta_data] : object_data_) {
-      if(meta_data.object_label_) meta_data.object_label_->setVisible(show_label);
+  for(auto&[_, disp] : object_data_) {
+      if(disp.object_label_) disp.object_label_->setVisible(show_label);
     }
-}
-
-void ObjectOdometryDisplay::updatePathDiameter() {
-  auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-  float line_width = path_diameter_property_->getFloat();
-
-  if (style == BILLBOARDS) {
-    for(auto& [object_id, object_meta_data] : object_data_) {
-      for (auto billboard_line : object_meta_data.billboard_lines_) {
-        if (billboard_line) {
-          billboard_line->setLineWidth(line_width);
-        }
-      }
-    }
-  }
   context_->queueRender();
+
 }
 
-void ObjectOdometryDisplay::updateTrajectoryStyle()
-{
-  auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-
-  if (style == BILLBOARDS) {
-    path_diameter_property_->show();
-  } else {
-    path_diameter_property_->hide();
-  }
-
-  updateTrajectoryBufferLength();
-}
-
-
-// void ObjectOdometryDisplay::updateShapeChoice() {}
-
-void ObjectOdometryDisplay::updateShapeVisibility() {}
-
-// void ObjectOdometryDisplay::updateColorAndAlpha() {}
-
-// void ObjectOdometryDisplay::updateArrowsGeometry() {}
 
 void ObjectOdometryDisplay::updateAxisGeometry() {
-  // for (const auto & axes : axes_) {
-  //   updateAxes(axes);
-  // }
-
-}
-
-void ObjectOdometryDisplay::updateTrajectoryBufferLength()
-{
-  // Destroy all path objects
-  destroyTrajectoryObjects();
-
-  // // Destroy all axes and arrows
-  // destroyPoseAxesChain();
-  // destroyPoseArrowChain();
-
-  // Read options
-  auto buffer_length = static_cast<size_t>(buffer_length_property_->getInt());
-  auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-
-  //allocate new data for all existing objects, sincee we have destroyed all the data in destroyTrajectoryObjects
-  for(auto&[_, object_meta_data] : object_data_) { allocateTrajectoryBuffer(object_meta_data,buffer_length,style); }
-
-}
-
-void ObjectOdometryDisplay::destroyTrajectoryObjects() {
-  // Destroy all simple lines, if any
-  auto destroy_per_object = [&](ObjectMetaData& object_meta_data) {
-    for (auto manual_object : object_meta_data.manual_objects_) {
-      manual_object->clear();
-      scene_manager_->destroyManualObject(manual_object);
-    }
-    object_meta_data.manual_objects_.clear();
-
-    // Destroy all billboards, if any
-    for (auto billboard_line : object_meta_data.billboard_lines_) {
-      delete billboard_line;  // also destroys the corresponding scene node
-    }
-    object_meta_data.billboard_lines_.clear();
-
-    if(object_meta_data.object_label_) {
-      object_meta_data.scene_node->detachObject(object_meta_data.object_label_);
-      delete object_meta_data.object_label_;
+  auto update_per_object = [&](SingleDisplay& disp) {
+    for (const auto & axes : disp.axes_) {
+      axes->set(axes_length_property_->getFloat(), axes_radius_property_->getFloat());
     }
   };
+  for(auto&[_, disp] : object_data_) { update_per_object(disp); }
 
-  for(auto&[_, object_meta_data] : object_data_) { destroy_per_object(object_meta_data); }
+  context_->queueRender();
+
+
 }
 
-void ObjectOdometryDisplay::addObjectData(
-  const Ogre::Vector3 & position, 
-  const Ogre::Quaternion & orientation,
-  dynamic_slam_interfaces::msg::ObjectOdometry::ConstSharedPtr msg)
+void ObjectOdometryDisplay::SingleDisplay::createAndAddAxes(
+  const Ogre::Vector3 & position, const Ogre::Quaternion & orientation,
+  float length, float radius)
 {
-  int object_label = msg->object_id;
-
-  auto msg_colour = msg->colour;
-  Ogre::ColourValue colour(msg_colour.r, msg_colour.g, msg_colour.b, 1);
-
-  if (object_data_.find(object_label) == object_data_.end()) {
-    auto buffer_length = static_cast<size_t>(buffer_length_property_->getInt());
-    auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-    //new object
-    ObjectMetaData new_object_data;
-
-    new_object_data.scene_node = scene_node_->createChildSceneNode();
-    //must allocate memory for new object when it is created!!
-    allocateTrajectoryBuffer(new_object_data, buffer_length, style);
-
-    const std::string label = "Object " + std::to_string(msg->object_id);
-    new_object_data.object_label_ = new rviz_rendering::MovableText(label);
-
-    //attach object to object scene scene node
-    new_object_data.scene_node->attachObject(new_object_data.object_label_);
-    //update frames local position relative to the 
-
-    new_object_data.object_label_->setVisible(show_object_label_property_->getBool());
-    new_object_data.object_label_->setTextAlignment(
-      rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_CENTER);
-    new_object_data.object_label_->setColor(colour);
-    object_data_.emplace(object_label, std::move(new_object_data));
-  }
-
-
-  ObjectMetaData& object_meta_data = object_data_.at(object_label);
-  size_t buffer_index = object_meta_data.messages_received_ % buffer_length_property_->getInt();
-
-  auto style = static_cast<LineStyle>(style_property_->getOptionInt());
-  Ogre::ManualObject * manual_object = nullptr;
-  rviz_rendering::BillboardLine * billboard_line = nullptr;
-
-  // Ogre::Matrix4 transform(orientation);
-  // transform.setTrans(position);
-
-  // std::cout << buffer_index << " " << object_meta_data.billboard_lines_.size() << std::endl;
-
-  object_meta_data.axes_.push_back(createAndSetAxes(position, orientation));
-  object_meta_data.covariances_.push_back(createAndSetCovarianceVisual(position, orientation, msg));
-
-  // Delete oldest element
-  switch (style) {
-    case LINES:
-      manual_object = object_meta_data.manual_objects_[buffer_index];
-      manual_object->clear();
-      break;
-
-    case BILLBOARDS:
-      billboard_line = object_meta_data.billboard_lines_[buffer_index];
-      billboard_line->clear();
-      billboard_line->setNumLines(1);
-      billboard_line->setMaxPointsPerLine(static_cast<uint32_t>(object_meta_data.axes_.size()));
-      billboard_line->setLineWidth(path_diameter_property_->getFloat());
-
-      // std::cout << colour.r << " " <<  colour.g << " " << colour.b << " " << colour.a << std::endl;
-
-      for (const auto& axes : object_meta_data.axes_) {
-        // Ogre::Vector3 xpos = transform * rviz_common::pointMsgToOgre(pose_stamped.pose.position);
-        auto xpos = axes->getPosition();
-        billboard_line->addPoint(xpos, colour);
-      }
-      break;
-  }
-
-  //update text location
-  // auto xpos = object_meta_data.axes_.back()->getPosition();
-  object_meta_data.scene_node->setPosition(position);
-
-  updateShowPoses();
-  updateShowTrajectory();
-  // updateShowVelocity()
-  updateShowObjectLabel();
-
-  object_meta_data.messages_received_++;
-
-}
-
-void ObjectOdometryDisplay::allocateTrajectoryBuffer(ObjectMetaData& object_meta_data, size_t buffer_length, LineStyle style) {
-  switch (style) {
-      case LINES:  // simple lines with fixed width of 1px
-        object_meta_data.manual_objects_.reserve(buffer_length);
-        for (size_t i = 0; i < buffer_length; i++) {
-          auto manual_object = scene_manager_->createManualObject();
-          manual_object->setDynamic(true);
-          scene_node_->attachObject(manual_object);
-
-          object_meta_data.manual_objects_.push_back(manual_object);
-        }
-        break;
-
-      case BILLBOARDS:  // billboards with configurable width
-        object_meta_data.billboard_lines_.reserve(buffer_length);
-        for (size_t i = 0; i < buffer_length; i++) {
-          auto billboard_line = new rviz_rendering::BillboardLine(scene_manager_, scene_node_);
-          object_meta_data.billboard_lines_.push_back(billboard_line);
-        }
-        break;
-    }
-}
-
-
-std::unique_ptr<rviz_rendering::Axes> ObjectOdometryDisplay::createAndSetAxes(
-    const Ogre::Vector3 & position, const Ogre::Quaternion & orientation) {
-
   auto axes = std::make_unique<rviz_rendering::Axes>(
-    scene_manager_, scene_node_->createChildSceneNode(),
-    axes_length_property_->getFloat(),
-    axes_radius_property_->getFloat());
+    scene_manager_, scene_node_,
+    length,
+    radius);
   axes->setPosition(position);
   axes->setOrientation(orientation);
   axes->getSceneNode()->setVisible(true);
-  return axes;
 
+  axes_.push_back(std::move(axes));
 }
 
- std::unique_ptr<rviz_rendering::CovarianceVisual> ObjectOdometryDisplay::createAndSetCovarianceVisual(
-    const Ogre::Vector3 & position,
-    const Ogre::Quaternion & orientation,
-    dynamic_slam_interfaces::msg::ObjectOdometry::ConstSharedPtr message) 
+void ObjectOdometryDisplay::SingleDisplay::createAndAddCovarianceVisual(
+  const Ogre::Vector3 & position,
+  const Ogre::Quaternion & orientation,
+  ObjectOdometry::ConstSharedPtr message)
 {
   auto covariance_visual = std::make_unique<rviz_rendering::CovarianceVisual>(
-    scene_manager_, scene_node_->createChildSceneNode());
+    scene_manager_, scene_node_);
   covariance_visual->setPosition(position);
   covariance_visual->setOrientation(orientation);
   auto quaternion = message->odom.pose.pose.orientation;
@@ -454,17 +230,23 @@ std::unique_ptr<rviz_rendering::Axes> ObjectOdometryDisplay::createAndSetAxes(
     rviz_common::quaternionMsgToOgre(quaternion), message->odom.pose.covariance);
   covariance_visual->updateUserData(show_covariance_property_->getUserData());
 
-  return covariance_visual;
-
+  covariances_.push_back(std::move(covariance_visual));
 }
 
+void ObjectOdometryDisplay::clear() {
+  auto update_per_object = [&](SingleDisplay& disp) {
+    disp.axes_.clear();
+    disp.covariances_.clear();
 
-void ObjectOdometryDisplay::ObjectMetaData::showOnlyFinalPose() {
-   for(auto& axes : axes_) {
-        axes->getSceneNode()->setVisible(false);
+    if(disp.object_label_) {
+      disp.object_label_scene_node_->detachObject(disp.object_label_);
+      delete disp.object_label_;
     }
-    auto& last_pose = axes_.back();
-    last_pose->getSceneNode()->setVisible(true);
+  };
+  for(auto&[_, disp] : object_data_) { update_per_object(disp); }
+
+  object_data_.clear();
+
 }
 
 

--- a/src/object_odometry_path_display.cc
+++ b/src/object_odometry_path_display.cc
@@ -1,0 +1,444 @@
+#include "rviz_dynamic_slam_plugins/object_odometry_path_display.hpp"
+
+#include <memory>
+#include <string>
+
+#include "rviz_rendering/objects/arrow.hpp"
+#include "rviz_rendering/objects/axes.hpp"
+
+#include "rviz_common/logging.hpp"
+#include "rviz_common/msg_conversions.hpp"
+#include "rviz_common/properties/color_property.hpp"
+#include "rviz_common/properties/covariance_property.hpp"
+#include "rviz_common/properties/enum_property.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/int_property.hpp"
+#include "rviz_common/properties/bool_property.hpp"
+#include "rviz_common/validate_floats.hpp"
+
+// #include "./quaternion_helper.hpp"
+
+namespace rviz_dynamic_slam_plugins
+{
+
+ObjectOdometryPathDisplay::ObjectOdometryPathDisplay(rviz_common::DisplayContext * context)
+: ObjectOdometryPathDisplay()
+{
+  context_ = context;
+  scene_manager_ = context->getSceneManager();
+  scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
+  updateBufferLength();
+}
+
+ObjectOdometryPathDisplay::ObjectOdometryPathDisplay()
+{
+  buffer_length_property_ = new rviz_common::properties::IntProperty(
+    "Buffer Length", 1,
+    "Number of paths to display.",
+    this, SLOT(updateBufferLength()));
+  buffer_length_property_->setMin(1);
+
+  properties.line_width_property_ = new rviz_common::properties::FloatProperty(
+    "Line Width", 0.03f,
+    "The width, in meters, of each path line."
+    "Only works with the 'Billboards' style.",
+    this, SLOT(updateLineWidth()), this);
+  properties.line_width_property_->setMin(0.001f);
+  properties.line_width_property_->hide();
+
+  properties.pose_style_property_ = new rviz_common::properties::EnumProperty(
+    "Pose Style", "None",
+    "Shape to display the pose as.",
+    this, SLOT(updatePoseStyle()));
+  properties.pose_style_property_->addOption("None", NONE);
+  properties.pose_style_property_->addOption("Axes", AXES);
+  properties.pose_style_property_->addOption("Arrows", ARROWS);
+
+  properties.pose_axes_length_property_ = new rviz_common::properties::FloatProperty(
+    "Length", 0.3f,
+    "Length of the axes.",
+    this, SLOT(updatePoseAxisGeometry()) );
+    properties.pose_axes_radius_property_ = new rviz_common::properties::FloatProperty(
+    "Radius", 0.03f,
+    "Radius of the axes.",
+    this, SLOT(updatePoseAxisGeometry()) );
+
+  properties.pose_arrow_shaft_length_property_ = new rviz_common::properties::FloatProperty(
+    "Shaft Length",
+    0.1f,
+    "Length of the arrow shaft.",
+    this,
+    SLOT(updatePoseArrowGeometry()));
+  properties.pose_arrow_head_length_property_ = new rviz_common::properties::FloatProperty(
+    "Head Length", 0.2f,
+    "Length of the arrow head.",
+    this,
+    SLOT(updatePoseArrowGeometry()));
+  properties.pose_arrow_shaft_diameter_property_ = new rviz_common::properties::FloatProperty(
+    "Shaft Diameter",
+    0.1f,
+    "Diameter of the arrow shaft.",
+    this,
+    SLOT(updatePoseArrowGeometry()));
+  properties.pose_arrow_head_diameter_property_ = new rviz_common::properties::FloatProperty(
+    "Head Diameter",
+    0.3f,
+    "Diameter of the arrow head.",
+    this,
+    SLOT(updatePoseArrowGeometry()));
+  properties.pose_axes_length_property_->hide();
+  properties.pose_axes_radius_property_->hide();
+  properties.pose_arrow_shaft_length_property_->hide();
+  properties.pose_arrow_head_length_property_->hide();
+  properties.pose_arrow_shaft_diameter_property_->hide();
+  properties.pose_arrow_head_diameter_property_->hide();
+}
+
+ObjectOdometryPathDisplay::~ObjectOdometryPathDisplay()
+{
+  destroyDisplays();
+}
+
+void ObjectOdometryPathDisplay::onInitialize()
+{
+  MFDClass::onInitialize();
+  updateBufferLength();
+}
+
+void ObjectOdometryPathDisplay::reset()
+{
+  MFDClass::reset();
+  updateBufferLength();
+}
+
+
+
+void ObjectOdometryPathDisplay::processMessage(dynamic_slam_interfaces::msg::MultiObjectOdometryPath::ConstSharedPtr msg)
+{
+  // // Calculate index of oldest element in cyclic buffer
+  size_t bufferIndex = messages_received_ % buffer_length_property_->getInt();
+  auto buffer_length = static_cast<size_t>(buffer_length_property_->getInt());
+  std::cout << "Gotten msg " << std::endl;
+
+  rviz_rendering::BillboardLine * billboard_line = nullptr;
+  //create object per path
+  for(const auto& path : msg->paths) {
+
+    SingleDisplay* display = nullptr;
+    const auto object_id = path.object_id;
+    if (object_data_.find(object_id) == object_data_.end()) {
+      std::cout << "making new object " << object_id << std::endl;
+
+      SingleDisplay object_display;
+      object_display.scene_node_ = scene_node_->createChildSceneNode();
+      object_display.scene_manager_ = scene_manager_;
+      object_display.pose_style_property_ = properties.pose_style_property_;
+      object_display.pose_axes_length_property_ = properties.pose_axes_length_property_;
+      object_display.pose_axes_radius_property_ = properties.pose_axes_radius_property_;
+      object_display.pose_arrow_shaft_length_property_ = properties.pose_arrow_shaft_length_property_;
+      object_display.pose_arrow_head_length_property_ = properties.pose_arrow_head_length_property_;
+      object_display.pose_arrow_shaft_diameter_property_ = properties.pose_arrow_shaft_diameter_property_;
+      object_display.pose_arrow_head_diameter_property_ = properties.pose_arrow_head_diameter_property_;
+      object_display.line_width_property_ = properties.line_width_property_;
+
+      object_display.updateBufferLength(buffer_length);
+
+
+      object_data_.emplace(object_id, std::move(object_display));
+
+    }
+
+    std::cout << "gotten new object " << object_id << std::endl;
+
+
+    display = &object_data_.at(object_id);
+    assert (display != nullptr);
+
+    std::cout << "gotten disp " << object_id << std::endl;
+
+    Ogre::Vector3 position;
+    Ogre::Quaternion orientation;
+    if (!context_->getFrameManager()->getTransform(path.header, position, orientation)) {
+      setMissingTransformToFixedFrame(path.header.frame_id);
+      return;
+    }
+
+    std::cout << "gotten position and orientation " << object_id << std::endl;
+    setTransformOk();
+
+    Ogre::Matrix4 transform(orientation);
+    transform.setTrans(position);
+
+    billboard_line = display->billboard_lines_[bufferIndex];
+    assert (billboard_line != nullptr);
+    billboard_line->clear();
+
+    std::cout << "gotten billboard_line " << object_id << std::endl;
+
+    display->updateBillBoardLine(billboard_line, path, transform);
+    display->updatePoseMarkers(bufferIndex, path, transform);
+
+    std::cout << "dome updaet " << object_id << std::endl;
+
+  }
+  context_->queueRender();
+
+
+}
+
+void ObjectOdometryPathDisplay::updateBufferLength() {
+  auto buffer_length = static_cast<size_t>(buffer_length_property_->getInt());
+  for(auto& [_, obj] : object_data_) {
+    obj.updateBufferLength(buffer_length);
+  }
+}
+
+void ObjectOdometryPathDisplay::destroyDisplays() {
+  for(auto& [_, obj] : object_data_) {
+    obj.destroyObjects();
+    obj.destroyPoseAxesChain();
+    obj.destroyPoseArrowChain();
+  }
+
+  object_data_.clear();
+}
+
+
+void ObjectOdometryPathDisplay::updateLineWidth() {
+  float line_width = properties.line_width_property_->getFloat();
+
+  for(auto& [_, obj] : object_data_) {
+    for (auto billboard_line : obj.billboard_lines_) {
+      if (billboard_line) {
+        billboard_line->setLineWidth(line_width);
+      }
+    }
+  }
+
+
+  context_->queueRender();
+}
+
+void ObjectOdometryPathDisplay::updatePoseStyle() {
+  auto pose_style = static_cast<PoseStyle>(properties.pose_style_property_->getOptionInt());
+  switch (pose_style) {
+    case AXES:
+      properties.pose_axes_length_property_->show();
+      properties.pose_axes_radius_property_->show();
+      properties.pose_arrow_shaft_length_property_->hide();
+      properties.pose_arrow_head_length_property_->hide();
+      properties.pose_arrow_shaft_diameter_property_->hide();
+      properties.pose_arrow_head_diameter_property_->hide();
+      break;
+    case ARROWS:
+      properties.pose_axes_length_property_->hide();
+      properties.pose_axes_radius_property_->hide();
+      properties.pose_arrow_shaft_length_property_->show();
+      properties.pose_arrow_head_length_property_->show();
+      properties.pose_arrow_shaft_diameter_property_->show();
+      properties.pose_arrow_head_diameter_property_->show();
+      break;
+    default:
+      properties.pose_axes_length_property_->hide();
+      properties.pose_axes_radius_property_->hide();
+      properties.pose_arrow_shaft_length_property_->hide();
+      properties.pose_arrow_head_length_property_->hide();
+      properties.pose_arrow_shaft_diameter_property_->hide();
+      properties.pose_arrow_head_diameter_property_->hide();
+  }
+  updateBufferLength();
+}
+
+void ObjectOdometryPathDisplay::updatePoseAxisGeometry() {
+  for(auto& [_, obj] : object_data_) {
+    for (auto & axes_vect : obj.axes_chain_) {
+      for (auto & axes : axes_vect) {
+        axes->set(
+          properties.pose_axes_length_property_->getFloat(),
+          properties.pose_axes_radius_property_->getFloat() );
+      }
+    }
+  }
+  context_->queueRender();
+}
+
+void ObjectOdometryPathDisplay::updatePoseArrowGeometry() {
+  for(auto& [_, obj] : object_data_) {
+    for (auto & arrow_vect : obj.arrow_chain_) {
+      for (auto & arrow : arrow_vect) {
+        arrow->set(
+          properties.pose_arrow_shaft_length_property_->getFloat(),
+          properties.pose_arrow_shaft_diameter_property_->getFloat(),
+          properties.pose_arrow_head_length_property_->getFloat(),
+          properties.pose_arrow_head_diameter_property_->getFloat());
+      }
+    }
+  }
+  context_->queueRender();
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::updateBufferLength(size_t buffer_length) {
+  // Destroy all path objects
+  destroyObjects();
+
+  // Destroy all axes and arrows
+  destroyPoseAxesChain();
+  destroyPoseArrowChain();
+
+  billboard_lines_.reserve(buffer_length);
+  for (size_t i = 0; i < buffer_length; i++) {
+    auto billboard_line = new rviz_rendering::BillboardLine(scene_manager_, scene_node_);
+    billboard_lines_.push_back(billboard_line);
+  }
+
+  axes_chain_.resize(buffer_length);
+  arrow_chain_.resize(buffer_length);
+
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::allocateAxesVector(std::vector<rviz_rendering::Axes *> & axes_vect, size_t num)
+{
+  auto vector_size = axes_vect.size();
+  if (num > vector_size) {
+    axes_vect.reserve(num);
+    for (auto i = vector_size; i < num; ++i) {
+      axes_vect.push_back(
+        new rviz_rendering::Axes(
+          scene_manager_, scene_node_,
+          pose_axes_length_property_->getFloat(),
+          pose_axes_radius_property_->getFloat()));
+    }
+  } else if (num < vector_size) {
+    for (auto i = num; i < vector_size; ++i) {
+      delete axes_vect[i];
+    }
+    axes_vect.resize(num);
+  }
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::allocateArrowVector(std::vector<rviz_rendering::Arrow *> & arrow_vect, size_t num)
+{
+  auto vector_size = arrow_vect.size();
+  if (num > vector_size) {
+    arrow_vect.reserve(num);
+    for (auto i = vector_size; i < num; ++i) {
+      arrow_vect.push_back(new rviz_rendering::Arrow(scene_manager_, scene_node_));
+    }
+  } else if (num < vector_size) {
+    for (auto i = num; i < vector_size; ++i) {
+      delete arrow_vect[i];
+    }
+    arrow_vect.resize(num);
+  }
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::destroyPoseAxesChain()
+{
+  for (auto & axes_vect : axes_chain_) {
+    allocateAxesVector(axes_vect, 0);
+  }
+  axes_chain_.clear();
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::destroyPoseArrowChain()
+{
+  for (auto & arrow_vect : arrow_chain_) {
+    allocateArrowVector(arrow_vect, 0);
+  }
+  arrow_chain_.clear();
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::destroyObjects() {
+  for (auto billboard_line : billboard_lines_) {
+    delete billboard_line;  // also destroys the corresponding scene node
+  }
+  billboard_lines_.clear();
+}
+
+
+void ObjectOdometryPathDisplay::SingleDisplay::updateBillBoardLine(
+  rviz_rendering::BillboardLine * billboard_line, const ObjectOdometryPath& msg,
+  const Ogre::Matrix4 & transform)
+{
+
+  auto msg_colour = msg.colour;
+  Ogre::ColourValue colour(msg_colour.r, msg_colour.g, msg_colour.b, 1);
+  
+  auto num_points = msg.object_odometries.size();
+  billboard_line->setNumLines(1);
+  billboard_line->setMaxPointsPerLine(static_cast<uint32_t>(num_points));
+  billboard_line->setLineWidth(line_width_property_->getFloat());
+
+  for (size_t i = 0; i < num_points; ++i) {
+    const geometry_msgs::msg::Point & pos = msg.object_odometries[i].odom.pose.pose.position;
+    Ogre::Vector3 xpos = transform * rviz_common::pointMsgToOgre(pos);
+    billboard_line->addPoint(xpos, colour);
+  }
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::updatePoseMarkers(
+  size_t buffer_index, const ObjectOdometryPath& msg, const Ogre::Matrix4 & transform)
+{
+  auto pose_style = static_cast<PoseStyle>(pose_style_property_->getOptionInt());
+  auto & arrow_vect = arrow_chain_[buffer_index];
+  auto & axes_vect = axes_chain_[buffer_index];
+
+  if (pose_style == AXES) {
+    updateAxesMarkers(axes_vect, msg, transform);
+  }
+  if (pose_style == ARROWS) {
+    updateArrowMarkers(arrow_vect, msg, transform);
+  }
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::updateAxesMarkers(
+  std::vector<rviz_rendering::Axes *> & axes_vect, const ObjectOdometryPath& msg,
+  const Ogre::Matrix4 & transform)
+{
+  auto num_points = msg.object_odometries.size();
+  allocateAxesVector(axes_vect, num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    const geometry_msgs::msg::Point & pos = msg.object_odometries[i].odom.pose.pose.position;
+    axes_vect[i]->setPosition(transform * rviz_common::pointMsgToOgre(pos));
+    Ogre::Quaternion orientation(rviz_common::quaternionMsgToOgre( msg.object_odometries[i].odom.pose.pose.orientation));
+
+    // Extract the rotation part of the transformation matrix as a quaternion
+    Ogre::Quaternion transform_orientation = transform.linear();
+
+    axes_vect[i]->setOrientation(transform_orientation * orientation);
+  }
+}
+
+void ObjectOdometryPathDisplay::SingleDisplay::updateArrowMarkers(
+  std::vector<rviz_rendering::Arrow *> & arrow_vect, const ObjectOdometryPath& msg,
+  const Ogre::Matrix4 & transform)
+{
+  auto num_points = msg.object_odometries.size();
+  allocateArrowVector(arrow_vect, num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    // QColor color = pose_arrow_color_property_->getColor();
+    // arrow_vect[i]->setColor(color.redF(), color.greenF(), color.blueF(), 1.0f);
+
+    arrow_vect[i]->set(
+      pose_arrow_shaft_length_property_->getFloat(),
+      pose_arrow_shaft_diameter_property_->getFloat(),
+      pose_arrow_head_length_property_->getFloat(),
+      pose_arrow_head_diameter_property_->getFloat());
+    const geometry_msgs::msg::Point & pos = msg.object_odometries[i].odom.pose.pose.position;
+    arrow_vect[i]->setPosition(transform * rviz_common::pointMsgToOgre(pos));
+    Ogre::Quaternion orientation(rviz_common::quaternionMsgToOgre(msg.object_odometries[i].odom.pose.pose.orientation));
+
+    // Extract the rotation part of the transformation matrix as a quaternion
+    Ogre::Quaternion transform_orientation = transform.linear();
+
+    Ogre::Vector3 dir(1, 0, 0);
+    dir = transform_orientation * orientation * dir;
+    arrow_vect[i]->setDirection(dir);
+  }
+}
+
+
+} //rviz_dynamic_slam_plugins
+
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(rviz_dynamic_slam_plugins::ObjectOdometryPathDisplay, rviz_common::Display)

--- a/test/multi_trajectory_generator.py
+++ b/test/multi_trajectory_generator.py
@@ -1,0 +1,204 @@
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Pose, PoseWithCovariance, Twist, TwistWithCovariance
+# from tf_transformations import quaternion_from_euler
+from scipy.spatial.transform import Rotation as R
+from dynamic_slam_interfaces.msg import ObjectOdometry, ObjectOdometryPath, MultiObjectOdometryPath
+from std_msgs.msg import ColorRGBA
+import random
+import math
+
+
+def hsv_to_rgb(h: float, s: float, v: float) -> tuple[float, float, float]:
+    """Converts HSV color to RGB color.
+
+    Args:
+        h (float): Hue (0.0 to 1.0).
+        s (float): Saturation (0.0 to 1.0).
+        v (float): Value (brightness) (0.0 to 1.0).
+
+    Returns:
+        tuple[float, float, float]: The RGB color (r, g, b), each value between 0.0 and 1.0.
+    """
+    if s == 0.0:  # achromatic (grey)
+        return v, v, v
+    i = math.floor(h * 6)
+    f = h * 6 - i
+    p = v * (1 - s)
+    q = v * (1 - f * s)
+    t = v * (1 - (1 - f) * s)
+
+    if i % 6 == 0:
+        r, g, b = v, t, p
+    elif i % 6 == 1:
+        r, g, b = q, v, p
+    elif i % 6 == 2:
+        r, g, b = p, v, t
+    elif i % 6 == 3:
+        r, g, b = p, q, v
+    elif i % 6 == 4:
+        r, g, b = t, p, v
+    elif i % 6 == 5:
+        r, g, b = v, p, q
+    return r, g, b
+
+
+def unique_id_rgb(id: int, saturation: float = 0.5, value: float = 0.95) -> tuple[float, float, float]:
+    """Maps an integer ID to a unique RGB color using the golden ratio for hue.
+
+    Args:
+        id (int): The unique identifier.
+        saturation (float, optional): Saturation of the color (0.0 to 1.0). Defaults to 1.0.
+        value (float, optional): Value (brightness) of the color (0.0 to 1.0). Defaults to 1.0.
+
+    Returns:
+        tuple[float, float, float]: The RGB color (r, g, b), each value between 0.0 and 1.0.
+    """
+    phi = (1 + math.sqrt(5)) / 2
+    n = (id * phi) % 1  # More efficient modulo
+    hue = (n * 256) % 256 / 255.0 # Ensure hue is in range 0-1
+
+    r, g, b = hsv_to_rgb(hue, saturation, value)
+    return r, g, b
+
+class TrajectoryGenerator:
+    def __init__(self, object_id, frame_id='odom', child_frame_id='base_link', max_speed=1.0, max_angular_speed=0.5):
+        self.object_id = object_id
+        self.frame_id = frame_id
+        self.child_frame_id = child_frame_id
+        self.max_speed = max_speed
+        self.max_angular_speed = max_angular_speed
+        self.position = [0.0, 0.0]  # x, y
+        self.orientation = 0.0      # yaw (in radians)
+        self.velocity = [0.0, 0.0]  # linear (x), angular (z)
+
+        self.colour = unique_id_rgb(self.object_id+1)
+
+        self.colour_msg = ColorRGBA()
+        self.colour_msg.r = self.colour[0]
+        self.colour_msg.g = self.colour[1]
+        self.colour_msg.b = self.colour[2]
+
+        self.path: ObjectOdometryPath = ObjectOdometryPath()
+        self.path.colour = self.colour_msg
+        self.path.object_id = self.object_id
+
+    def generate_random_velocity(self):
+        """Generate random linear and angular velocities."""
+        linear_speed = random.uniform(-self.max_speed, self.max_speed)
+        angular_speed = random.uniform(-self.max_angular_speed, self.max_angular_speed)
+        return linear_speed, angular_speed
+
+    def update_position(self, dt):
+        """Update the position and orientation based on current velocities."""
+        linear_speed = self.velocity[0]
+        angular_speed = self.velocity[1]
+
+        # Update orientation
+        self.orientation += angular_speed * dt
+        self.orientation = math.fmod(self.orientation, 2 * math.pi)  # Keep within [-pi, pi]
+
+        # Update position (2D kinematic equations)
+        self.position[0] += linear_speed * math.cos(self.orientation) * dt
+        self.position[1] += linear_speed * math.sin(self.orientation) * dt
+
+    def generate_odometry(self, timestamp):
+        """Generate an Odometry message for the current state."""
+        self.velocity = self.generate_random_velocity()
+        odom_msg = Odometry()
+        odom_msg.header.stamp = timestamp
+        odom_msg.header.frame_id = self.frame_id
+        odom_msg.child_frame_id = self.child_frame_id
+
+        # Set position and orientation
+        odom_msg.pose.pose.position.x = self.position[0]
+        odom_msg.pose.pose.position.y = self.position[1]
+        odom_msg.pose.pose.position.z = 0.0
+        quat = R.from_euler("xyz", [0.0, 0.0, self.orientation]).as_quat()
+        # quat = quaternion_from_euler(0.0, 0.0, self.orientation)  # Roll, pitch, yaw
+        odom_msg.pose.pose.orientation.x = quat[0]
+        odom_msg.pose.pose.orientation.y = quat[1]
+        odom_msg.pose.pose.orientation.z = quat[2]
+        odom_msg.pose.pose.orientation.w = quat[3]
+
+        # Set twist (linear and angular velocity)
+        odom_msg.twist.twist.linear.x = self.velocity[0]
+        odom_msg.twist.twist.angular.z = self.velocity[1]
+
+        object_odom = ObjectOdometry()
+        object_odom.odom = odom_msg
+        object_odom.object_id = self.object_id
+
+    
+        object_odom.colour = self.colour_msg
+        
+        self.path.object_odometries.append(object_odom)
+        self.path.header = odom_msg.header
+
+        return self.path
+
+class RandomTrajectoryNode(Node):
+    def __init__(self):
+        super().__init__('random_trajectory_node')
+
+        # Parameters
+        self.publish_rate = self.declare_parameter('publish_rate', 10.0).value  # Hz
+        self.num_trajectories = self.declare_parameter('num_trajectories', 3).value
+        self.max_speed = self.declare_parameter('max_speed', 1.0).value         # m/s
+        self.max_angular_speed = self.declare_parameter('max_angular_speed', 0.5).value  # rad/s
+
+        # Publisher
+        self.odom_publisher = self.create_publisher(MultiObjectOdometryPath, 'object_odom', 10)
+
+        # Timer
+        self.timer = self.create_timer(1.0 / self.publish_rate, self.publish_odometries)
+
+        # Trajectory Generators
+        self.trajectories = [
+            TrajectoryGenerator(
+                object_id=int(i),
+                frame_id=f'odom',
+                child_frame_id=f'base_link',
+                max_speed=self.max_speed,
+                max_angular_speed=self.max_angular_speed
+            ) for i in range(self.num_trajectories)
+        ]
+
+        self.current_time = self.get_clock().now()
+
+        self.get_logger().info('Random Trajectory Node has been started.')
+
+    def publish_odometries(self):
+        """Publish odometry messages for all trajectories."""
+        now = self.get_clock().now()
+        dt = (now - self.current_time).nanoseconds * 1e-9
+        self.current_time = now
+
+        multi_path = MultiObjectOdometryPath()
+        multi_path.header.stamp = now.to_msg()
+        multi_path.header.frame_id = "odom"
+
+        for trajectory in self.trajectories:
+            trajectory.update_position(dt)
+            path = trajectory.generate_odometry(now.to_msg())
+            multi_path.paths.append(path)
+            # self.odom_publisher.publish(odom_msg)
+            self.get_logger().info(f'Creating odometry for {trajectory.child_frame_id}: position={trajectory.position}, orientation={trajectory.orientation}')
+
+        self.odom_publisher.publish(multi_path)
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = RandomTrajectoryNode()
+    rclpy.spin(node)
+    # try:
+    #     rclpy.spin(node)
+    # except KeyboardInterrupt:
+    #     node.get_logger().info('Node terminated by user. Shutting down.')
+    # finally:
+    #     node.destroy_node()
+    #     rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- split ObjectOdom messages into pure odometry and path messages
- associated with branch in dynamic_slam_interfaces of same name
- ObjectOdomDisplay is just to display the current odometry of the object (like the regular odometry message)
- MultiObjectOdomPathDisplay introduced to draw the full path of the objects based on a MultiObjectOdomPath message